### PR TITLE
fix config module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "^2.0.5"
   },
   "scripts": {
-    "start": "node /server/api/index.js",
+    "start": "node server/api/index.js",
     "_eslint": "eslint .",
     "_prettier": "prettier .",
     "format": "run-s '_prettier -- --write' '_eslint -- --fix'",

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -30,7 +30,7 @@ app.get('/', async(req,res) => {
 /** Call to  database **/
 
 
-mongoose.connect(config.get('database'))
+mongoose.connect('mongodb+srv://stn-admin:aV7JHuEcTtywIE27@cluster0-lvbc6.mongodb.net/stn-database?retryWrites=true&w=majority')
 .then(() => console.log('Connected to SayTheirName Node Service database \n --------------- \n'))
 .catch(error => console.error('Could not connect to database' + error))
 


### PR DESCRIPTION
Exposing the credentials because .config ```npm start``` error