### PR TITLE
GitHub workflow to deploy app to Heroku

### DIFF
--- a/.github/workflows/ci-cd-workflow.yaml
+++ b/.github/workflows/ci-cd-workflow.yaml
@@ -1,0 +1,24 @@
+name: CICD
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v3.0.4
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+
+      - name: Set Heroku config vars
+        run: |
+          heroku config:set DATABASE_URI=$DATABASE_URI
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          DATABASE_URI: ${{ secrets.DATABASE_URI }}

--- a/server/api/config/custom-environment-variables.json
+++ b/server/api/config/custom-environment-variables.json
@@ -1,3 +1,0 @@
-{
-    "database":"mongodb+srv://stn-admin:aV7JHuEcTtywIE27@cluster0-lvbc6.mongodb.net/stn-database?retryWrites=true&w=majority"
-}

--- a/server/api/config/default.json
+++ b/server/api/config/default.json
@@ -1,4 +1,0 @@
-  
-{
-    "database":"mongodb+srv://stn-admin:aV7JHuEcTtywIE27@cluster0-lvbc6.mongodb.net/stn-database?retryWrites=true&w=majority"
-}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const mongoose = require('mongoose')
-const config = require('config')
 const path = require('path')
 const port = process.env.PORT || 3000
 
@@ -30,7 +29,7 @@ app.get('/', async(req,res) => {
 /** Call to  database **/
 
 
-mongoose.connect('mongodb+srv://stn-admin:aV7JHuEcTtywIE27@cluster0-lvbc6.mongodb.net/stn-database?retryWrites=true&w=majority')
+mongoose.connect(process.env.DATABASE_URI)
 .then(() => console.log('Connected to SayTheirName Node Service database \n --------------- \n'))
 .catch(error => console.error('Could not connect to database' + error))
 


### PR DESCRIPTION
## Overview ###
This enables the MongoDB URI to be passed in as an environment variable accessible at runtime by the application. 

## Important Setup Notes ##
- Since we are deploying to Heroku using a workflow we should remove the automated deploy configuration in Heroku 
- An authorization token or API key must be set in GitHub secrets as `HEROKU_API_KEY` to deploy to Heroku. An API Key can be found at dashboard.heroku.com under "Account settings" or an authorization token can be configured using the Heroku CLI:

```
$ heroku login
$ heroku authorizations:create
Creating OAuth Authorization... done
Client:      <none>
ID:          123456789-my-id
Description: Long-lived user authorization
Scope:       global
Token:       123456789-my-token
Updated at:  Sun Jun 14 2020 18:59:04 GMT-0700 (Pacific Daylight Time) (less than a minute ago)
```
- The Heroku app name must be set in GitHub Secrets as `HEROKU_APP_NAME`
- The email used for the Heroku app must be set in GitHub Secrets as `HEROKU_EMAIL`
- The MongoDB URI must be set in GitHub Secrets as `DATABASE_URI`

## Example of this workflow working ##
On my forked repo you can see this [workflow successfully](https://github.com/TheDoctorCam/say-their-names-node-service/runs/771104542?check_suite_focus=true) deploying the app to Heroku. 

Additionally on my forked repo, I updated the apps base path route to return the value of `DATABASE_URI` (which I set to be `TEST`) as a response to demonstrate that the environment variables are set and accessible at runtime:

```
app.get('/', async(req,res) => {
    res.set('Content-Type', 'application/json')
    res.send(process.env.DATABASE_URI)
})
```

Result: https://a6d8fe77b.herokuapp.com/

## Final Note ##
If you feel like the MongoDB URI in plaintext is sensitive data that you want to be removed from git history we can do [this](https://help.github.com/en/github/authenticating-to-github/removing-sensitive-data-from-a-repository).